### PR TITLE
Net next dpll v13 dpll pin caps fixes

### DIFF
--- a/Documentation/driver-api/dpll.rst
+++ b/Documentation/driver-api/dpll.rst
@@ -124,7 +124,7 @@ attributes with current state related to each parent, like:
 'pin': [{{
   'clock-id': 282574471561216,
   'module-name': 'ice',
-  'dpll-caps': 4,
+  'capabilities': 4,
   'id': 13,
   'parent-pin': [
   {'parent-id': 2, 'state': 'connected'},
@@ -277,8 +277,7 @@ according to attribute purpose.
       ``DPLL_A_PIN_PARENT_ID``         attr parent pin id
       ``DPLL_A_PIN_STATE``             attr state of pin on the parent
                                        pin
-    ``DPLL_A_PIN_DPLL_CAPS``           attr bitmask of pin-dpll
-                                       capabilities
+    ``DPLL_A_PIN_CAPABILITIES``        attr bitmask of pin capabilities
   ==================================== ==================================
 
   ==================================== =================================

--- a/Documentation/netlink/specs/dpll.yaml
+++ b/Documentation/netlink/specs/dpll.yaml
@@ -150,10 +150,10 @@ definitions:
     render-max: true
   -
     type: flags
-    name: pin-caps
+    name: pin-capabilities
     doc: |
       defines possible capabilities of a pin, valid flags on
-      DPLL_A_PIN_CAPS attribute
+      DPLL_A_PIN_CAPABILITIES attribute
     entries:
       -
         name: direction-can-change
@@ -260,7 +260,7 @@ attribute-sets:
         type: u32
         enum: pin-state
       -
-        name: dpll-caps
+        name: capabilities
         type: u32
       -
         name: parent-device
@@ -436,7 +436,7 @@ operations:
             - type
             - frequency
             - frequency-supported
-            - dpll-caps
+            - capabilities
             - parent-device
             - parent-pin
 

--- a/drivers/dpll/dpll_netlink.c
+++ b/drivers/dpll/dpll_netlink.c
@@ -374,7 +374,7 @@ dpll_cmd_pin_get_one(struct sk_buff *msg, struct dpll_pin *pin,
 		return -EMSGSIZE;
 	if (nla_put_u32(msg, DPLL_A_PIN_TYPE, prop->type))
 		return -EMSGSIZE;
-	if (nla_put_u32(msg, DPLL_A_PIN_DPLL_CAPS, prop->capabilities))
+	if (nla_put_u32(msg, DPLL_A_PIN_CAPABILITIES, prop->capabilities))
 		return -EMSGSIZE;
 	ret = dpll_msg_add_pin_freq(msg, pin, ref, extack);
 	if (ret)
@@ -595,7 +595,8 @@ dpll_pin_on_pin_state_set(struct dpll_pin *pin, u32 parent_idx,
 	unsigned long i;
 	int ret;
 
-	if (!(DPLL_PIN_CAPS_STATE_CAN_CHANGE & pin->prop->capabilities)) {
+	if (!(DPLL_PIN_CAPABILITIES_STATE_CAN_CHANGE &
+	      pin->prop->capabilities)) {
 		NL_SET_ERR_MSG(extack, "state changing is not allowed");
 		return -EOPNOTSUPP;
 	}
@@ -630,7 +631,8 @@ dpll_pin_state_set(struct dpll_device *dpll, struct dpll_pin *pin,
 	struct dpll_pin_ref *ref;
 	int ret;
 
-	if (!(DPLL_PIN_CAPS_STATE_CAN_CHANGE & pin->prop->capabilities)) {
+	if (!(DPLL_PIN_CAPABILITIES_STATE_CAN_CHANGE &
+	      pin->prop->capabilities)) {
 		NL_SET_ERR_MSG(extack, "state changing is not allowed");
 		return -EOPNOTSUPP;
 	}
@@ -656,7 +658,8 @@ dpll_pin_prio_set(struct dpll_device *dpll, struct dpll_pin *pin,
 	struct dpll_pin_ref *ref;
 	int ret;
 
-	if (!(DPLL_PIN_CAPS_PRIORITY_CAN_CHANGE & pin->prop->capabilities)) {
+	if (!(DPLL_PIN_CAPABILITIES_PRIORITY_CAN_CHANGE &
+	      pin->prop->capabilities)) {
 		NL_SET_ERR_MSG(extack, "prio changing is not allowed");
 		return -EOPNOTSUPP;
 	}
@@ -683,7 +686,8 @@ dpll_pin_direction_set(struct dpll_pin *pin, struct dpll_device *dpll,
 	struct dpll_pin_ref *ref;
 	int ret;
 
-	if (!(DPLL_PIN_CAPS_DIRECTION_CAN_CHANGE & pin->prop->capabilities)) {
+	if (!(DPLL_PIN_CAPABILITIES_DIRECTION_CAN_CHANGE &
+	      pin->prop->capabilities)) {
 		NL_SET_ERR_MSG(extack, "direction changing is not allowed");
 		return -EOPNOTSUPP;
 	}

--- a/drivers/net/ethernet/intel/ice/ice_dpll.c
+++ b/drivers/net/ethernet/intel/ice/ice_dpll.c
@@ -1655,9 +1655,10 @@ ice_dpll_init_info_direct_pins(struct ice_pf *pf,
 			if (ret)
 				return ret;
 			pins[i].prop.capabilities |=
-				DPLL_PIN_CAPS_PRIORITY_CAN_CHANGE;
+				DPLL_PIN_CAPABILITIES_PRIORITY_CAN_CHANGE;
 		}
-		pins[i].prop.capabilities |= DPLL_PIN_CAPS_STATE_CAN_CHANGE;
+		pins[i].prop.capabilities |=
+			DPLL_PIN_CAPABILITIES_STATE_CAN_CHANGE;
 		ret = ice_dpll_pin_state_update(pf, &pins[i], pin_type, NULL);
 		if (ret)
 			return ret;
@@ -1685,7 +1686,7 @@ static int ice_dpll_init_info_rclk_pin(struct ice_pf *pf)
 	struct ice_dpll_pin *pin = &pf->dplls.rclk;
 
 	pin->prop.type = DPLL_PIN_TYPE_SYNCE_ETH_PORT;
-	pin->prop.capabilities |= DPLL_PIN_CAPS_STATE_CAN_CHANGE;
+	pin->prop.capabilities |= DPLL_PIN_CAPABILITIES_STATE_CAN_CHANGE;
 	pin->pf = pf;
 
 	return ice_dpll_pin_state_update(pf, pin,

--- a/drivers/net/ethernet/mellanox/mlx5/core/dpll.c
+++ b/drivers/net/ethernet/mellanox/mlx5/core/dpll.c
@@ -196,7 +196,7 @@ static const struct dpll_pin_ops mlx5_dpll_pins_ops = {
 
 static const struct dpll_pin_properties mlx5_dpll_pin_properties = {
 	.type = DPLL_PIN_TYPE_SYNCE_ETH_PORT,
-	.capabilities = DPLL_PIN_CAPS_STATE_CAN_CHANGE,
+	.capabilities = DPLL_PIN_CAPABILITIES_STATE_CAN_CHANGE,
 };
 
 #define MLX5_DPLL_PERIODIC_WORK_INTERVAL 500 /* ms */

--- a/drivers/ptp/ptp_ocp.c
+++ b/drivers/ptp/ptp_ocp.c
@@ -2306,7 +2306,7 @@ ptp_ocp_sma_fb_init(struct ptp_ocp *bp)
 	struct dpll_pin_properties prop = {
 		.board_label = NULL,
 		.type = DPLL_PIN_TYPE_EXT,
-		.capabilities = DPLL_PIN_CAPS_DIRECTION_CAN_CHANGE,
+		.capabilities = DPLL_PIN_CAPABILITIES_DIRECTION_CAN_CHANGE,
 		.freq_supported_num = ARRAY_SIZE(ptp_ocp_sma_freq),
 		.freq_supported = ptp_ocp_sma_freq,
 
@@ -2331,7 +2331,7 @@ ptp_ocp_sma_fb_init(struct ptp_ocp *bp)
 			bp->sma[i].fixed_fcn = true;
 			bp->sma[i].fixed_dir = true;
 			bp->sma[1].dpll_prop.capabilities &=
-				~DPLL_PIN_CAPS_DIRECTION_CAN_CHANGE;
+				~DPLL_PIN_CAPABILITIES_DIRECTION_CAN_CHANGE;
 		}
 		return;
 	}
@@ -2522,12 +2522,12 @@ ptp_ocp_art_sma_init(struct ptp_ocp *bp)
 		case 8:
 			bp->sma[i].mode = SMA_MODE_IN;
 			bp->sma[i].dpll_prop.capabilities =
-				DPLL_PIN_CAPS_DIRECTION_CAN_CHANGE;
+				DPLL_PIN_CAPABILITIES_DIRECTION_CAN_CHANGE;
 			break;
 		default:
 			bp->sma[i].mode = SMA_MODE_OUT;
 			bp->sma[i].dpll_prop.capabilities =
-				DPLL_PIN_CAPS_DIRECTION_CAN_CHANGE;
+				DPLL_PIN_CAPABILITIES_DIRECTION_CAN_CHANGE;
 			break;
 		}
 	}

--- a/include/uapi/linux/dpll.h
+++ b/include/uapi/linux/dpll.h
@@ -126,16 +126,16 @@ enum dpll_pin_state {
 };
 
 /**
- * enum dpll_pin_caps - defines possible capabilities of a pin, valid flags on
- *   DPLL_A_PIN_CAPS attribute
- * @DPLL_PIN_CAPS_DIRECTION_CAN_CHANGE: pin direction can be changed
- * @DPLL_PIN_CAPS_PRIORITY_CAN_CHANGE: pin priority can be changed
- * @DPLL_PIN_CAPS_STATE_CAN_CHANGE: pin state can be changed
+ * enum dpll_pin_capabilities - defines possible capabilities of a pin, valid
+ *   flags on DPLL_A_PIN_CAPABILITIES attribute
+ * @DPLL_PIN_CAPABILITIES_DIRECTION_CAN_CHANGE: pin direction can be changed
+ * @DPLL_PIN_CAPABILITIES_PRIORITY_CAN_CHANGE: pin priority can be changed
+ * @DPLL_PIN_CAPABILITIES_STATE_CAN_CHANGE: pin state can be changed
  */
-enum dpll_pin_caps {
-	DPLL_PIN_CAPS_DIRECTION_CAN_CHANGE = 1,
-	DPLL_PIN_CAPS_PRIORITY_CAN_CHANGE = 2,
-	DPLL_PIN_CAPS_STATE_CAN_CHANGE = 4,
+enum dpll_pin_capabilities {
+	DPLL_PIN_CAPABILITIES_DIRECTION_CAN_CHANGE = 1,
+	DPLL_PIN_CAPABILITIES_PRIORITY_CAN_CHANGE = 2,
+	DPLL_PIN_CAPABILITIES_STATE_CAN_CHANGE = 4,
 };
 
 enum dpll_a {
@@ -170,7 +170,7 @@ enum dpll_a_pin {
 	DPLL_A_PIN_FREQUENCY_MAX,
 	DPLL_A_PIN_PRIO,
 	DPLL_A_PIN_STATE,
-	DPLL_A_PIN_DPLL_CAPS,
+	DPLL_A_PIN_CAPABILITIES,
 	DPLL_A_PIN_PARENT_DEVICE,
 	DPLL_A_PIN_PARENT_PIN,
 


### PR DESCRIPTION
updated examples for cover letter

- dump dpll devices
sudo ./tools/net/ynl/cli.py --spec Documentation/netlink/specs/dpll.yaml \
--dump device-get
[{'clock-id': 4658613174691613800,
  'id': 0,
  'lock-status': 'locked-ho-acq',
  'mode': 'automatic',
  'mode-supported': ['automatic'],
  'module-name': 'ice',
  'type': 'eec'},
 {'clock-id': 4658613174691613800,
  'id': 1,
  'lock-status': 'locked-ho-acq',
  'mode': 'automatic',
  'mode-supported': ['automatic'],
  'module-name': 'ice',
  'type': 'pps'}]

- get single pin info:
$ sudo ./tools/net/ynl/cli.py --spec Documentation/netlink/specs/dpll.yaml \
--do pin-get --json '{"id":2}'
{'board-label': 'C827_0-RCLKA',
 'clock-id': 4658613174691613800,
 'capabilities': 6,
 'frequency': 1953125,
 'id': 2,
 'module-name': 'ice',
 'parent-device': [{'direction': 'input',
                    'parent-id': 0,
                    'prio': 9,
                    'state': 'disconnected'},
                   {'direction': 'input',
                    'parent-id': 1,
                    'prio': 9,
                    'state': 'disconnected'}],
 'type': 'mux'}

- set pin's state on dpll:
$ sudo ./tools/net/ynl/cli.py --spec Documentation/netlink/specs/dpll.yaml \
--do pin-set --json '{"id":2, "parent-device":{"parent-id":1, "state":2}}'


- set pin's prio on dpll:
$ sudo ./tools/net/ynl/cli.py --spec Documentation/netlink/specs/dpll.yaml \
--do pin-set --json '{"id":2, "parent-device":{"parent-id":1, "prio":4}}'

- set pin's state on parent pin:
$ sudo ./tools/net/ynl/cli.py --spec Documentation/netlink/specs/dpll.yaml \
--do pin-set --json '{"id":13, "parent-pin":{"parent-id":2, "state":1}}'
